### PR TITLE
Add Gemfile and preview instructions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Welcome to PMHive, your comprehensive hub for product management resources. Our 
 
 PMHive also powers a GitHub Pages site through `index.md`. Many of the category files are currently placeholders, so we welcome your contributions to help fill them with high-quality content.
 
+Dependencies for the site are managed with Bundler. Use the provided `Gemfile` and run `bundle exec jekyll serve` to preview the site locally.
+
 ## Table of Contents
 
 - [Introduction](#introduction)


### PR DESCRIPTION
## Summary
- add a standard Gemfile for Github Pages
- document preview instructions in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f5cc76aa08333b9d90ecedb836128