### PR TITLE
Add basic Jekyll default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+  {% if site.theme %}
+    <!-- If a theme provides styles, include them -->
+    <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
+  {% endif %}
+</head>
+<body>
+  <header>
+    <h1><a href="{{ '/' | relative_url }}">{{ site.title }}</a></h1>
+    <nav>
+      <ul>
+        {% for my_page in site.pages %}
+          {% if my_page.title and my_page.nav != false %}
+            <li><a href="{{ my_page.url | relative_url }}">{{ my_page.title }}</a></li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </nav>
+  </header>
+  <main>
+    {{ content }}
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Jekyll default layout to `_layouts`

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5cc942588333bfacf18c117a46a4